### PR TITLE
fix(discord): update broken discord invite link

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -205,7 +205,7 @@ const Footer = () => (
             <Link href="https://www.facebook.com/groups/ucla.icpc" isExternal>
               <Box as={FaFacebook} w={8} h={8} />
             </Link>
-            <Link href="https://discord.gg/3a6kx2y9" isExternal>
+            <Link href="https://discord.gg/jPXmBEWDgv" isExternal>
               <Box as={FaDiscord} w={8} h={8} />
             </Link>
             <Link href="https://www.instagram.com/acm.ucla" isExternal>


### PR DESCRIPTION
The Discord invite link on our website was broken, this updates it to a never expiring invite to `#welcome`.