### PR TITLE
fix(discord): remove temporary discord invite link and replace with official

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -205,7 +205,7 @@ const Footer = () => (
             <Link href="https://www.facebook.com/groups/ucla.icpc" isExternal>
               <Box as={FaFacebook} w={8} h={8} />
             </Link>
-            <Link href="https://discord.gg/jPXmBEWDgv" isExternal>
+            <Link href="https://discord.gg/6pxWhttfs6" isExternal>
               <Box as={FaDiscord} w={8} h={8} />
             </Link>
             <Link href="https://www.instagram.com/acm.ucla" isExternal>


### PR DESCRIPTION
The old discord link only granted temporary membership, replace it with the "official" invite: discord.gg/6pxWhttfs6